### PR TITLE
Add overwrite method

### DIFF
--- a/dftogsheet/__init__.py
+++ b/dftogsheet/__init__.py
@@ -5,17 +5,18 @@ from dftogsheet.config import Config
 from dftogsheet.sheet import *
 
 
-def write_section_to_sheet(df_subsection, spreadsheet_id, sheet_name, offset=0):
-    section = sheet.Sheet(df_subsection)
-    section.unsupported_datatypes_tostr()
-    section.set_range(sheet_name=sheet_name, offset=offset)
-    config = Config()
-    section.write(spreadsheet_id, config)
-
-
 def write_to_sheet(df, spreadsheet_id, sheet_name):
+    config = Config()
+
     # Headers
-    write_section_to_sheet(df.columns, spreadsheet_id, sheet_name)
+    headers = sheet.Sheet(df.columns)
+    headers.unsupported_datatypes_tostr()
+    headers.set_range(sheet_name=sheet_name)
+    headers.overwrite(spreadsheet_id, config)
+
     # Body
-    write_section_to_sheet(df.values, spreadsheet_id, sheet_name, offset=1)
+    body = sheet.Sheet(df.values)
+    body.unsupported_datatypes_tostr()
+    body.set_range(sheet_name=sheet_name, offset=1)
+    body.write(spreadsheet_id, config)
     

--- a/dftogsheet/sheet.py
+++ b/dftogsheet/sheet.py
@@ -1,5 +1,6 @@
 import datetime as dt
 import pandas as pd
+import numpy as np
 
 from dftogsheet import auth
 
@@ -65,12 +66,26 @@ class Sheet:
             except Exception as e:
                 print(e)
 
+    def overwrite(self, spreadsheet_id, config):
+        # Create large array and overwrite sheet
+        list = []
+        for i in range(0, 200000):
+            list.append('')
+        array = np.array(list).reshape(200,1000)
+        df = pd.DataFrame(data=array)
+        blank_sheet = Sheet(df.values)
+        blank_sheet.set_range(sheet_name=self.range.sheet_name)
+        blank_sheet.write(spreadsheet_id, config)
+        # Call normal write method
+        self.write(spreadsheet_id, config)
+
 
 class Range:
     first_row = 1
     last_row = 1
     first_col = 1
     last_col = 1
+    sheet_name = None
     
     def __init__(self, sheet_value, offset):
         if not isinstance(offset, int):
@@ -89,6 +104,7 @@ class Range:
     def set_str(self, sheet_name=False):
         string = ''
         if sheet_name:
+            self.sheet_name = sheet_name
             string = f'{sheet_name}!'
         fc = self.first_col.to_alph()
         lc = self.last_col.to_alph()


### PR DESCRIPTION
This update adds the `overwrite()` method to the `Sheet` class, which writes a blank block of 200x1000 cells before calling the normal write method.

This update also includes `overwrite()` by default in the `write_to_sheet` function.